### PR TITLE
fix image url issues with ocp example

### DIFF
--- a/documentation/modules/ROOT/examples/build-resources.yaml
+++ b/documentation/modules/ROOT/examples/build-resources.yaml
@@ -20,4 +20,4 @@ spec:
     - name: url
       value: "example.com/rhdevelopers/tekton-tutorial-greeter"
       # if you are on OpenShift uncomment the line below
-      #value: "image-registry.openshift-image-registry.svc:5000/tutorial/helloworld"
+      #value: "image-registry.openshift-image-registry.svc:5000/tektontutorial/helloworld"

--- a/documentation/modules/ROOT/pages/_partials/openshift-setup.adoc
+++ b/documentation/modules/ROOT/pages/_partials/openshift-setup.adoc
@@ -54,7 +54,7 @@ It will take few minutes for the openshift-pipelines components to be installed,
 [#check-pipelines]
 [source,bash,subs="+macros,+attributes"]
 ----
-oc get pods -n openshift-pipelines -w 
+oc get pods -n openshift-pipelines -w
 ----
 copyToClipboard::check-pipelines[]
 
@@ -68,6 +68,15 @@ NAME                                           READY   STATUS    RESTARTS   AGE
 tekton-pipelines-controller-855f895846-jgh99   1/1     Running   0          2m20s
 tekton-pipelines-webhook-c98b564d5-dtt5z       1/1     Running   0          2m21s
 -----
+
+All the tutorial exercises will be deployed in namespace called `{tutorial-namespace}`:
+
+[#setup-tekton-tutorial-ns]
+[source,bash,subs="+macros,+attributes"]
+----
+oc new-project {tutorial-namespace}
+----
+copyToClipboard::setup-tekton-tutorial-ns[]
 
 **Congratulations!** You have now installed all the OpenShift pipelines components to run the tutorial exercises. You can terminate the WATCH_WINDOW using kbd:[Ctrl+c].
 

--- a/documentation/modules/ROOT/pages/tasks.adoc
+++ b/documentation/modules/ROOT/pages/tasks.adoc
@@ -460,7 +460,7 @@ endif::[]
 [#tekton-app-run-to-oc]
 [source,bash,subs="+macros,attributes+"]
 ----
-oc run demo-greeter -n {tutorial-namespace} --generator='run-pod/v1' --image='dev.local/rhdevelopers/tekton-tutorial-greeter' && \
+oc run demo-greeter -n {tutorial-namespace} --generator='run-pod/v1' --image='image-registry.openshift-image-registry.svc:5000/tektontutorial/helloworld' && \
 oc expose pod demo-greeter -n {tutorial-namespace} --port 8080 --type=NodePort && \
 oc expose svc -n {tutorial-namespace} demo-greeter
 ----

--- a/pipelines/build-resources.yaml
+++ b/pipelines/build-resources.yaml
@@ -21,4 +21,4 @@ spec:
       # use internal registry
       value: example.com/rhdevelopers/tekton-tutorial-greeter
       # if you are on OpenShift uncomment the line below
-      #value: "image-registry.openshift-image-registry.svc:5000/tutorial/helloworld"
+      #value: "image-registry.openshift-image-registry.svc:5000/tektontutorial/helloworld"


### PR DESCRIPTION
As @kameshsampath described (and helped) with this issue (https://github.com/redhat-developer-demos/tekton-tutorial/issues/3) the proper namespace needs to be specified into the image url.

Is there any way in anphora render the {tutorial-namespace} inside of the --image to not hardcode this?