### PR TITLE
Errors I found while running the tutorial against Minikube

### DIFF
--- a/apps/minikube-registry-helper/configure.sh
+++ b/apps/minikube-registry-helper/configure.sh
@@ -7,7 +7,7 @@ set -o pipefail
 minikube -p tektontutorial addons enable registry
 
 sleep 5; 
-while (echo && oc get pods -n kube-system --selector='kubernetes.io/minikube-addons=registry' \
+while (echo && kubectl get pods -n kube-system --selector='kubernetes.io/minikube-addons=registry' \
    | grep -v -E "(Running|Completed|STATUS)"); 
 do 
   sleep 5; 

--- a/documentation/modules/ROOT/examples/svc-deploy.yaml
+++ b/documentation/modules/ROOT/examples/svc-deploy.yaml
@@ -7,9 +7,9 @@ spec:
     - name: contextDir
       description: the context directory from where to build the application
   resources:
-    - name: source
+    - name: appSource
       type: git
-    - name: builtImage
+    - name: appImage
       type: image
   tasks:
     - name: build-java-app
@@ -21,10 +21,10 @@ spec:
       resources:
         inputs:
           - name: source
-            resource: source
+            resource: appSource
         outputs:
           - name: builtImage
-            resource: builtImage
+            resource: appImage
     - name: deploy-kubernetes-service
       taskRef:
         name: openshift-client

--- a/documentation/modules/ROOT/pages/_attributes.adoc
+++ b/documentation/modules/ROOT/pages/_attributes.adoc
@@ -3,7 +3,7 @@
 :branch: master
 :github-repo: https://github.com/redhat-developer-demos/tekton-tutorial/blob/{branch}
 :experimental:
-:minikube-version: v1.8.2+
+:minikube-version: v1.8.2
 :openshift-version: v4.2+
 
 :tekton-repo: https://github.com/tektoncd/pipeline/releases/download

--- a/documentation/modules/ROOT/pages/_partials/minikube-setup.adoc
+++ b/documentation/modules/ROOT/pages/_partials/minikube-setup.adoc
@@ -1,7 +1,7 @@
 [#start-minikube]
 **Configure and Start Minikube**
 
-Before installing Knative and its components, we need to create a Minikube virtual machine and deploy Kubernetes into it.
+Before installing Tekton and its components, we need to create a Minikube virtual machine and deploy Kubernetes into it.
 
 Download https://kubernetes.io/docs/setup/minikube[minikube] and add it to your path.
 

--- a/documentation/modules/ROOT/pages/_partials/prereq-cli.adoc
+++ b/documentation/modules/ROOT/pages/_partials/prereq-cli.adoc
@@ -11,7 +11,7 @@ Kubernetes::
 [#minikube-set-env]
 [source,bash,subs="+macros,+attributes"]
 ----
-eval $(minikube docker-env)
+eval $(minikube docker-env -p tektontutorial)
 ----
 copyToClipboard::minikube-set-env[]
 

--- a/documentation/modules/ROOT/pages/pipelines.adoc
+++ b/documentation/modules/ROOT/pages/pipelines.adoc
@@ -295,7 +295,7 @@ Kubernetes::
 [#tekton-invoke-app-k8s]
 [source,bash,subs="+macros,attributes+"]
 ----
-SVC_URL=$(minikube -p {tutorial-namespace} -n {tutorial-namespace} service helloworld --url) && \
+SVC_URL=$(minikube -p {tutorial-namespace} -n {tutorial-namespace} service greeter --url) && \
 http --body $SVC_URL
 ----
 copyToClipboard::tekton-invoke-app-k8s[]
@@ -308,7 +308,7 @@ endif::[]
 [source,bash,subs="+macros,attributes+"]
 ----
 oc expose svc helloworld
-SVC_URL=$(oc get routes helloworld -o yaml | yq r - 'spec.url.host' )
+SVC_URL=$(oc get routes greeter -o yaml | yq r - 'spec.url.host' )
 http --body $SVC_URL
 ----
 copyToClipboard::tekton-invoke-app-oc[]

--- a/documentation/modules/ROOT/pages/setup.adoc
+++ b/documentation/modules/ROOT/pages/setup.adoc
@@ -84,7 +84,7 @@ ifndef::workshop[]
 [#kubernetes-cluster]
 == Choose your Kubernetes Cluster
 
-Knative can be installed only on Kubernetes cluster. The following section shows how to install Knative on vanilla https://kubernetes.io[Kubernetes] or on Red Hat https://www.openshift.com[Openshift] -- an enterprise grade Kubernetes platform --
+Tekton can be installed only on Kubernetes cluster. The following section shows how to install Tekton on vanilla https://kubernetes.io[Kubernetes] or on Red Hat https://www.openshift.com[Openshift] -- an enterprise grade Kubernetes platform --
 
 [tabs]
 ====

--- a/documentation/modules/ROOT/pages/tasks.adoc
+++ b/documentation/modules/ROOT/pages/tasks.adoc
@@ -86,7 +86,7 @@ Now you can use the `tkn` CLI tool to run the Task, you can pass the parameters 
 [#run-task-source-lister]
 [source,bash,subs="+macros,+attributes"]
 ----
-tkn task start source-lister --inputresource='source=git-source' #<1>
+tkn task start source-lister --inputresource='source=git-source' #<1> --showlog
 ----
 copyToClipboard::run-task-source-lister[]
 
@@ -585,7 +585,7 @@ kubectl::
 [source,bash,subs="+macros,+attributes"]
 ----
 kubectl get pod -n {tutorial-namespace} build-app-run-bsr4k-pod-xbxwg\
--o=jsonpath="{range .spec.containers[*]} {.name} {'\n'} {.volumeMounts[?(@.name=='varlibc')]} {'\n'} {end}"
+-o=jsonpath="{range .spec.containers[*]} {.name} {'\n'} {.securityContext} {'\n'} {end}"
 ----
 copyToClipboard::apply-check-sc[]
 --
@@ -596,7 +596,7 @@ oc::
 [source,bash,subs="+macros,+attributes"]
 ----
 oc get pod -n {tutorial-namespace} build-app-run-bsr4k-pod-xbxwg\
--o=jsonpath="{range .spec.containers[*]} {.name} {'\n'} {.volumeMounts[?(@.name=='varlibc')]} {'\n'} {end}"
+-o=jsonpath="{range .spec.containers[*]} {.name} {'\n'} {.securityContext} {'\n'} {end}"
 ----
 copyToClipboard::oc-check-sc[]
 --


### PR DESCRIPTION
Please note that I change the Minikube version because I first tested
against Minikube 1.9.2 which is based on Kubernetes 1.18.x which adds
a new field in the metadata that causes the Tekton webhook to fail
because it can decode the payload (maybe this is fixed in latest Tekton

Signed-off-by: Jeff MAURY <jmaury@redhat.com>